### PR TITLE
Change reload to not require worker to listen

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,10 +133,10 @@ module.exports = function(file, opt) {
                 // possible leftover worker that has no channel estabilished 
                 // will throw
                 try { worker.disconnect(); } catch (e) { }
-                cluster.removeListener('listening', stopOld);
+                cluster.removeListener('online', stopOld);
             });
 
-            cluster.on('listening', stopOld);
+            cluster.on('online', stopOld);
         });
         for (var i = 0; i < opt.workers; ++i) 
             cluster.fork({WORKER_ID: i})._rc_wid = i;


### PR DESCRIPTION
I'm a Colleague of the reporter in issue #2, 

We have a cluster were the workers do not listen on a port, they are processors for a redis-based system.  When we send a SIGUSR2 to other clusters which do listen those restart using the "listening" approach.  Using the "online" approach has fixed this problem for our non-listening workers and still works for the other clusters which do implement a listener.
