### PR TITLE
Send disconnect message to worker process.

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ module.exports = function(file, opt) {
                 if (opt.timeout > 0) {
                     var timeout = setTimeout(killfn, opt.timeout * 1000);
                     worker.on('exit', clearTimeout.bind(this, timeout));
+                    worker.send({cmd: 'disconnect'});
                 } else {
                     killfn();
                 }


### PR DESCRIPTION
Here is the PR for #9. My only concern here is that I am sending `send`ing a message immediately before calling `disconnect`. Is there a chance that disconnect will close the IPC channel before the message is sent/delivered? I don't think so, because I see this in child_process.js:

``` js
  target.disconnect = function() {
    if (!this.connected) {
      this.emit('error', new Error('IPC channel is already disconnected'));
      return;
    }

    // do not allow messages to be written
    this.connected = false;
    this._channel = null;

    var fired = false;
    function finish() {
      if (fired) return;
      fired = true;

      channel.close();
      target.emit('disconnect');
    }

    // If a message is being read, then wait for it to complete.
    if (channel.buffering) {
      this.once('message', finish);
      this.once('internalMessage', finish);

      return;
    }

    process.nextTick(finish);
  };
```

So I think the channel will stay open until this message is delivered (if it is the only message -- if there's more than one in flight, maybe the channel will close before any after the first are delivered?).
