### PR TITLE
add a stop() method which terminates cluster management but not workers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,18 +234,23 @@ module.exports = function(file, opt) {
     };
 
     self.terminate = function() {
-        if (!cluster.isMaster) return;
-        cluster.removeListener('exit', workerEmitExit);
-        cluster.removeListener('disconnect', workerDisconnect);
-        cluster.removeListener('listening', workerListening);
-        cluster.removeListener('online', workerOnline);
-        respawners.cancel();
+        self.stop()
         self.workers.forEach(function (worker) {
             if (worker.kill)
                 worker.kill('SIGKILL');
             else
                 worker.destroy();
         });
+    }
+
+    self.stop = function() {
+        if (!cluster.isMaster) return;
+        cluster.removeListener('exit', workerEmitExit);
+        cluster.removeListener('disconnect', workerDisconnect);
+        cluster.removeListener('listening', workerListening);
+        cluster.removeListener('online', workerOnline);
+        respawners.cancel();
+
         channel.removeAllListeners();
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -268,4 +268,16 @@ runTest("IPC-disconnecting server", dmsgSettings, function(t) {
 
 });
 
+runTest("stopped cluster", termSettings, function(t) {
+    var wrkpids = pids();
+    setTimeout(function() {
+        balancer.stop();
+    }, timeToSpawn);
+    setTimeout(function() {
+        var wrkpids2 = pids(); 
+        t.equal(wrkpids2.length, 0, "0 workers should be active"); 
+        t.end();
+    }, timeoutWorker + timeToSpawn);
+});
+
 


### PR DESCRIPTION
Not sure if I'm just doing it wrong, but I have a case where:
1. I want to allow open http connections to finish out before gracefully exiting
2. My workers can catch a SIGTERM/SIGINT and handle their own cleanup
3. The master should allow all workers to exit before shutting things down

So, I want to allow my workers to suicide on completion, and have the master not respawn the workers, but then close out when completed. This seems to allow for that case. Specifically, the fact that terminate() does a SIGKILL prevents me from using it, and this seems more flexible.
