### PR TITLE
recluster.terminate accepts a callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ module.exports = function(file, opt) {
         for (var i = 0; i < opt.workers; ++i) fork(i);
     };
 
-    self.terminate = function() {
+    self.terminate = function(callback) {
         self.stop()
         self.workers.forEach(function (worker) {
             if (worker.kill)
@@ -257,6 +257,7 @@ module.exports = function(file, opt) {
             else
                 worker.destroy();
         });
+        cluster.disconnect(callback);
     }
 
     self.stop = function() {

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,16 @@ runTest("manual ready signal",
 });
 
 
+runTest("callback on terminate", {workers: 2, file: 'server-ok.js', timeout: 1}, function (t) {
+    lib.setServer('server-ok.js', function (err) {
+        t.ok(!err, "server should start");
+        t.equal(lib.balancer.workers.length, 2, "2 workers present");
+        lib.balancer.terminate(function () {
+            t.equal(lib.balancer.workers.length, 0, "0 workers present");
+            t.end();
+        });
+    });
+});
 
 
 runTest("broken server", function(t) {


### PR DESCRIPTION
Hey!

This is a follow up for #33 
Please note, that my test fails. I posted this PR, because reviewing the code here will be easier than in the issues. 

Can you give me some pointers, I'm in a bit of a pickle - after the cluster terminates it should have 0 workers right? The test fails with message, that it expects 0 workers but `balancer.workers.length` is equal to 1.

PS, on linux and nodejs 0.12 only 27 of 33 tests pass, without my changes.