### PR TITLE
Option to set the signal type when terminating

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,12 +217,16 @@ module.exports = function(file, opt) {
         for (var i = 0; i < opt.workers; ++i) fork(i);
     };
 
-    self.terminate = function(cb) {
+    self.terminate = function(signal, cb) {
+        var hasCustomSignal = typeof(signal) === 'string';
+        cb = hasCustomSignal ? cb : signal;
+        signal = hasCustomSignal ? signal : 'SIGKILL';
         self.stop()
         cluster.on('exit', allDone);
         workers.forEach(function (worker) {
+            worker = worker.process || worker;
             if (worker.kill)
-                worker.kill('SIGKILL');
+                worker.kill(signal);
             else
                 worker.destroy();
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recluster",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Clustering library with support for zero-downtime reloading",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The use case is running inside a docker container. The container exits as soon as the foreground process exits. In the docker context, the foreground process is the cluster master.

To handle graceful exits properly, I need the cluster master to stay alive until workers have exited gracefully.

When the docker container stops it sends a `SIGTERM` to the foreground process. My workers handle this `SIGTERM` and exit gracefully, but I need to be able to forward the signal from the master to the workers and have the master wait for the workers.

The client `cluster.js` file looks like this:

``` js
process.on('SIGTERM', () => {
  cluster.terminate('SIGTERM', () => {
    process.exit();
  });
});
```
